### PR TITLE
CasAuthenticationClient uses Caller-Id header

### DIFF
--- a/scala-cas_2.11/pom.xml
+++ b/scala-cas_2.11/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.11</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.11</name>
     <properties>

--- a/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
+++ b/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
@@ -19,16 +19,16 @@ object CasAuthenticatingClient extends Logging {
   def apply(casClient: CasClient,
             casParams: CasParams,
             serviceClient: Client,
-            clientSubSystemCode: Option[String],
+            clientCallerId: Option[String],
             sessionCookieName: String): Client = {
-    new CasAuthenticatingClient(casClient, casParams, serviceClient, clientSubSystemCode, sessionCookieName).httpClient
+    new CasAuthenticatingClient(casClient, casParams, serviceClient, clientCallerId, sessionCookieName).httpClient
   }
 }
 
 class CasAuthenticatingClient(casClient: CasClient,
                               casParams: CasParams,
                               serviceClient: Client,
-                              clientSubSystemCode: Option[String],
+                              clientCallerId: Option[String],
                               sessionCookieName: String) extends Logging {
   lazy val httpClient = Client(
     open = Service.lift(open),
@@ -50,8 +50,8 @@ class CasAuthenticatingClient(casClient: CasClient,
   private def addHeaders(req: Request, session: SessionCookie): Request = {
     val csrf = "CasAuthenticatingClient"
     var list: ListBuffer[Header] = ListBuffer(headers.Cookie(Cookie(sessionCookieName, session), Cookie("CSRF", csrf)), Header("CSRF", csrf))
-    clientSubSystemCode.foreach { cssc =>
-      list += Header("clientSubSystemCode", cssc)
+    clientCallerId.foreach { callerId =>
+      list += Header("Caller-Id", callerId)
     }
     req.putHeaders(list: _*)
   }

--- a/scala-cas_2.12/pom.xml
+++ b/scala-cas_2.12/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.12</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.12</name>
     <properties>

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
@@ -19,16 +19,16 @@ object CasAuthenticatingClient extends Logging {
   def apply(casClient: CasClient,
             casParams: CasParams,
             serviceClient: Client,
-            clientSubSystemCode: Option[String],
+            clientCallerId: Option[String],
             sessionCookieName: String): Client = {
-    new CasAuthenticatingClient(casClient, casParams, serviceClient, clientSubSystemCode, sessionCookieName).httpClient
+    new CasAuthenticatingClient(casClient, casParams, serviceClient, clientCallerId, sessionCookieName).httpClient
   }
 }
 
 class CasAuthenticatingClient(casClient: CasClient,
                               casParams: CasParams,
                               serviceClient: Client,
-                              clientSubSystemCode: Option[String],
+                              clientCallerId: Option[String],
                               sessionCookieName: String) extends Logging {
   lazy val httpClient = Client(
     open = Service.lift(open),
@@ -50,8 +50,8 @@ class CasAuthenticatingClient(casClient: CasClient,
   private def addHeaders(req: Request, session: SessionCookie): Request = {
     val csrf = "CasAuthenticatingClient"
     var list: ListBuffer[Header] = ListBuffer(headers.Cookie(Cookie(sessionCookieName, session), Cookie("CSRF", csrf)), Header("CSRF", csrf))
-    clientSubSystemCode.foreach { cssc =>
-      list += Header("clientSubSystemCode", cssc)
+    clientCallerId.foreach { callerId =>
+      list += Header("Caller-Id", callerId)
     }
     req.putHeaders(list: _*)
   }


### PR DESCRIPTION
In the future Opintopolku API calls are required to have `Caller-Id` header
Changes CasAuthenticationClient to use `Caller-Id` header instead of `clientSubSystemCode` header.

- changes cas_2.12 
- changes cas_2.11