### PR TITLE
Update http4s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.vm.sade</groupId>
     <artifactId>scala-utils</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>scala-utils</name>
     <packaging>pom</packaging>
     <organization>

--- a/scala-captcha_2.11/pom.xml
+++ b/scala-captcha_2.11/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-captcha_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-captcha_2.11</name>
     <dependencies>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>fi.vm.sade</groupId>
             <artifactId>scala-json_2.11</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/scala-cas_2.11/pom.xml
+++ b/scala-cas_2.11/pom.xml
@@ -39,17 +39,17 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-            <version>0.15.9</version>
+            <version>0.16.6a</version>
         </dependency>
         <dependency>
             <groupId>org.http4s</groupId>
             <artifactId>http4s-dsl_${scala.compat.version}</artifactId>
-            <version>0.15.9</version>
+            <version>0.16.6a</version>
         </dependency>
         <dependency>
             <groupId>org.http4s</groupId>
             <artifactId>http4s-blaze-client_${scala.compat.version}</artifactId>
-            <version>0.15.9</version>
+            <version>0.16.6a</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/scala-cas_2.11/pom.xml
+++ b/scala-cas_2.11/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.11</name>
     <properties>

--- a/scala-cas_2.12/pom.xml
+++ b/scala-cas_2.12/pom.xml
@@ -39,17 +39,17 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-            <version>0.15.9</version>
+            <version>0.16.6a</version>
         </dependency>
         <dependency>
             <groupId>org.http4s</groupId>
             <artifactId>http4s-dsl_${scala.compat.version}</artifactId>
-            <version>0.15.9</version>
+            <version>0.16.6a</version>
         </dependency>
         <dependency>
             <groupId>org.http4s</groupId>
             <artifactId>http4s-blaze-client_${scala.compat.version}</artifactId>
-            <version>0.15.9</version>
+            <version>0.16.6a</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/scala-cas_2.12/pom.xml
+++ b/scala-cas_2.12/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.12</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.12</name>
     <properties>

--- a/scala-json_2.11/pom.xml
+++ b/scala-json_2.11/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-json_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-json_2.11</name>
     <dependencyManagement>

--- a/scala-json_2.12/pom.xml
+++ b/scala-json_2.12/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-json_2.12</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-json_2.12</name>
     <dependencyManagement>

--- a/scala-ldap-client_2.11/pom.xml
+++ b/scala-ldap-client_2.11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-ldap-client_2.11</artifactId>

--- a/scala-logging_2.11/pom.xml
+++ b/scala-logging_2.11/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-logging_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-logging_2.11</name>
     <dependencies>

--- a/scala-logging_2.12/pom.xml
+++ b/scala-logging_2.12/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-logging_2.12</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-logging_2.12</name>
     <dependencies>

--- a/scala-properties_2.11/pom.xml
+++ b/scala-properties_2.11/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-properties_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-properties_2.11</name>
     <dependencies>

--- a/scala-properties_2.12/pom.xml
+++ b/scala-properties_2.12/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-properties_2.12</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-properties_2.12</name>
     <dependencies>

--- a/scala-user-details_2.11/pom.xml
+++ b/scala-user-details_2.11/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>scala-utils</artifactId>
         <groupId>fi.vm.sade</groupId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>scala-user-details_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>scala-user-details_2.11</name>
     <packaging>jar</packaging>
 
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>fi.vm.sade</groupId>
             <artifactId>scala-utils_2.11</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>

--- a/scala-utils-validator_2.11/pom.xml
+++ b/scala-utils-validator_2.11/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-utils-validator_2.11</artifactId>

--- a/scala-utils_2.11/pom.xml
+++ b/scala-utils_2.11/pom.xml
@@ -4,18 +4,18 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-utils_2.11</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-utils_2.11</name>
     <dependencies>
         <dependency>
             <groupId>fi.vm.sade</groupId>
             <artifactId>scala-logging_2.11</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/scala-utils_2.12/pom.xml
+++ b/scala-utils_2.12/pom.xml
@@ -4,18 +4,18 @@
     <parent>
         <groupId>fi.vm.sade</groupId>
         <artifactId>scala-utils</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-utils_2.12</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-utils_2.12</name>
     <dependencies>
         <dependency>
             <groupId>fi.vm.sade</groupId>
             <artifactId>scala-logging_2.12</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
http4s 0.15.9 uses scalaz 7.1, but most other libraries use scalaz 7.2. 

0.16.6a uses scalaz 7.2. Later versions replace scalaz, which is a more breaking change.

See https://http4s.org/versions/