### PR TITLE
BUG-1987 part 2: log after retry in getServiceTicketWithRetryOnce

### DIFF
--- a/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -1,0 +1,28 @@
+package fi.vm.sade.utils.cas
+
+import java.net.ConnectException
+
+import fi.vm.sade.utils.cas.CasClient.SessionCookie
+import org.http4s.client.blaze
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.util.{Failure, Try}
+
+class CasClientSmokeTest extends FreeSpec with Matchers {
+
+  val params: CasParams = CasParams("http://service", "suffix", "u", "pw")
+
+  "CasClient fetch session should fail with correct (inner) exception instead of some functional problem" in {
+    val virkailijaUrl = "testiUrl"
+    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient)
+
+    val result: Try[SessionCookie] = Try(casClient.fetchCasSession(params).unsafePerformSync)
+
+    (result match {
+      case Failure(e) if e.isInstanceOf[ConnectException] && e.getMessage.equals("Connection refused") =>
+        true
+      case _ =>
+        false
+    }) shouldBe true
+  }
+}

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -56,7 +56,18 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client) extends Logging 
         Task(success)
       case -\/(throwable) =>
         logger.warn("Fetching TGT or ST failed. Retrying once (and only once) in case the error was ephemeral.", throwable)
-        getServiceTicket(params, serviceUri)
+        retryServiceTicket(params, serviceUri)
+    }
+  }
+
+  private def retryServiceTicket(params: CasParams, serviceUri: TGTUrl): Task[ServiceTicket] = {
+    getServiceTicket(params, serviceUri).attempt.map {
+      case \/-(retrySuccess) =>
+        logger.info("Fetching TGT and ST was successful after one retry.")
+        retrySuccess
+      case -\/(retryThrowable) =>
+        logger.error("Fetching TGT or ST failed also after one retry.", retryThrowable)
+        throw retryThrowable
     }
   }
 

--- a/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -1,0 +1,28 @@
+package fi.vm.sade.utils.cas
+
+import java.net.ConnectException
+
+import fi.vm.sade.utils.cas.CasClient.SessionCookie
+import org.http4s.client.blaze
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.util.{Failure, Try}
+
+class CasClientSmokeTest extends FreeSpec with Matchers {
+
+  val params: CasParams = CasParams("http://service", "suffix", "u", "pw")
+
+  "CasClient fetch session should fail with correct (inner) exception instead of some functional problem" in {
+    val virkailijaUrl = "testiUrl"
+    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient)
+
+    val result: Try[SessionCookie] = Try(casClient.fetchCasSession(params).unsafePerformSync)
+
+    (result match {
+      case Failure(e) if e.isInstanceOf[ConnectException] && e.getMessage.equals("Connection refused") =>
+        true
+      case _ =>
+        false
+    }) shouldBe true
+  }
+}


### PR DESCRIPTION
See https://github.com/Opetushallitus/scala-utils/pull/15

On second thought, it would be nicer to log also what happens after the retry, not just before.

Also a small unit test to make sure the function doesn't fail due to a runtime exception when the retry fails.