### PR TITLE
HLE-1258 Add CallerId parameter to CasClient (2.11 and 2.12)

### DIFF
--- a/scala-cas_2.11/pom.xml
+++ b/scala-cas_2.11/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.11</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.11</name>
     <properties>

--- a/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasAuthenticatingClientIntegrationTest.scala
+++ b/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasAuthenticatingClientIntegrationTest.scala
@@ -20,7 +20,7 @@ class CasAuthenticatingClientIntegrationTest extends FreeSpec with Matchers {
     val virkailijaUser: String = requiredEnv("VIRKAILIJA_USER")
     val virkailijaPassword: String = requiredEnv("VIRKAILIJA_PASSWORD")
 
-    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient)
+    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient, "my-caller-id")
     val casAuthenticatingClient = CasAuthenticatingClient(
       casClient,
       CasParams("/authentication-service", virkailijaUser, virkailijaPassword),

--- a/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -15,7 +15,7 @@ class CasClientSmokeTest extends FreeSpec with Matchers {
 
   "CasClient fetch session should fail with correct (inner) exception instead of some functional problem" in {
     val virkailijaUrl = "http://localhost:" + PortChecker.findFreeLocalPort()
-    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient)
+    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient, "my-caller-id")
 
     val result: Try[SessionCookie] = Try(casClient.fetchCasSession(params).unsafePerformSync)
 

--- a/scala-cas_2.12/pom.xml
+++ b/scala-cas_2.12/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.12</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.12</name>
     <properties>

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -21,13 +21,13 @@ object CasClient {
 /**
  *  Facade for establishing sessions with services protected by CAS, and also validating CAS service tickets.
  */
-class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client) extends Logging {
+class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String) extends Logging {
   import CasClient._
 
-  def this(casServer: String, client: Client) = this(Uri.fromString(casServer).toOption.get, client)
+  def this(casServer: String, client: Client, callerId: String) = this(Uri.fromString(casServer).toOption.get, client, callerId)
 
   def validateServiceTicket(service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    ServiceTicketValidator.validateServiceTicket(virkailijaLoadBalancerUrl, client, service)(serviceTicket)
+    ServiceTicketValidator.validateServiceTicket(virkailijaLoadBalancerUrl, client, callerId, service)(serviceTicket)
   }
 
   /**
@@ -44,7 +44,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client) extends Logging 
 
     for (
       st <- getServiceTicketWithRetryOnce(params, serviceUri);
-      session <- SessionCookieClient.getSessionCookieValue(client, serviceUri, sessionCookieName)(st)
+      session <- SessionCookieClient.getSessionCookieValue(client, serviceUri, sessionCookieName, callerId)(st)
     ) yield {
       session
     }
@@ -73,7 +73,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client) extends Logging 
 
   private def getServiceTicket(params: CasParams, serviceUri: TGTUrl): Task[ServiceTicket] = {
     for (
-      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(virkailijaLoadBalancerUrl, client, params);
+      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(virkailijaLoadBalancerUrl, client, params, callerId);
       st <- ServiceTicketClient.getServiceTicketFromTgt(client, serviceUri)(tgt)
     ) yield {
       st
@@ -82,7 +82,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client) extends Logging 
 }
 
 private[cas] object ServiceTicketValidator {
-  def validateServiceTicket(virkailijaLoadBalancerUrl: Uri, client: Client, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
+  def validateServiceTicket(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
     val pUri: Uri = resolve(virkailijaLoadBalancerUrl, uri("/cas/serviceValidate"))
       .withQueryParam("ticket", serviceTicket)
       .withQueryParam("service",service)
@@ -104,7 +104,7 @@ private[cas] object ServiceTicketValidator {
       }
     }
 
-    FetchHelper.fetch(client, task, handler)
+    FetchHelper.fetch(client, callerId, task, handler)
   }
 }
 
@@ -130,7 +130,7 @@ private[cas] object TicketGrantingTicketClient extends Logging {
   import CasClient.TGTUrl
   val tgtPattern = "(.*TGT-.*)".r
 
-  def getTicketGrantingTicket(virkailijaLoadBalancerUrl: Uri, client: Client, params: CasParams): Task[TGTUrl] = {
+  def getTicketGrantingTicket(virkailijaLoadBalancerUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
     val tgtUri: TGTUrl = resolve(virkailijaLoadBalancerUrl, uri("/cas/v1/tickets"))
     val task = POST(tgtUri, UrlForm("username" -> params.user.username, "password" -> params.user.password))
 
@@ -154,14 +154,14 @@ private[cas] object TicketGrantingTicketClient extends Logging {
         }
       }
     }
-    FetchHelper.fetch(client, task, handler)
+    FetchHelper.fetch(client, callerId, task, handler)
   }
 }
 
 private[cas] object SessionCookieClient {
   import CasClient._
 
-  def getSessionCookieValue(client: Client, service: Uri, sessionCookieName: String)(serviceTicket: ServiceTicket): Task[SessionCookie] = {
+  def getSessionCookieValue(client: Client, service: Uri, sessionCookieName: String, callerId: String)(serviceTicket: ServiceTicket): Task[SessionCookie] = {
     val sessionIdUri: Uri = service.withQueryParam("ticket", List(serviceTicket)).asInstanceOf[Uri]
     val task = GET(sessionIdUri)
 
@@ -178,16 +178,15 @@ private[cas] object SessionCookieClient {
       }
     }
 
-    FetchHelper.fetch(client, task, handler)
+    FetchHelper.fetch(client, callerId, task, handler)
   }
 }
 
 private object FetchHelper {
-  private val callerId = "scala-utils.scala-cas_2.12"
-  private val defaultHeaders: Header = Header("Caller-Id", callerId)
+  private def defaultHeaders(callerId: String) : Header = Header("Caller-Id", callerId)
 
-  def fetch[A](client: Client, task: Task[Request], handler: Response => Task[A]): Task[A] = {
-    val taskWithHeaders = task.putHeaders(defaultHeaders)
+  def fetch[A](client: Client, callerId: String, task: Task[Request], handler: Response => Task[A]): Task[A] = {
+    val taskWithHeaders = task.putHeaders(defaultHeaders(callerId))
     client.fetch(taskWithHeaders)(handler)
   }
 }

--- a/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasAuthenticatingClientIntegrationTest.scala
+++ b/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasAuthenticatingClientIntegrationTest.scala
@@ -20,7 +20,7 @@ class CasAuthenticatingClientIntegrationTest extends FreeSpec with Matchers {
     val virkailijaUser: String = requiredEnv("VIRKAILIJA_USER")
     val virkailijaPassword: String = requiredEnv("VIRKAILIJA_PASSWORD")
 
-    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient)
+    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient, "my-caller-id")
     val casAuthenticatingClient = CasAuthenticatingClient(
       casClient,
       CasParams("/authentication-service", virkailijaUser, virkailijaPassword),

--- a/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -15,7 +15,7 @@ class CasClientSmokeTest extends FreeSpec with Matchers {
 
   "CasClient fetch session should fail with correct (inner) exception instead of some functional problem" in {
     val virkailijaUrl = "http://localhost:" + PortChecker.findFreeLocalPort()
-    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient)
+    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient, "my-caller-id")
 
     val result: Try[SessionCookie] = Try(casClient.fetchCasSession(params).unsafePerformSync)
 


### PR DESCRIPTION
Instead of hardcoded value, it is now the responsibility
of caller to specify the callerId value.

It i s a non-backwards compatible change, the major version number is updated