### PR TITLE
fix CAS client relative URI path handling and make clients cas-oppija aware

### DIFF
--- a/scala-cas_2.11/pom.xml
+++ b/scala-cas_2.11/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.11</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.11</name>
     <properties>

--- a/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
+++ b/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
@@ -60,8 +60,10 @@ class CasAuthenticatingClient(casClient: CasClient,
     }
   }
 
-  private def isRedirectToLogin(resp: Response): Boolean =
-    resp.status.code == Status.Found.code && resp.headers.get(Location).exists(_.value.contains("/cas/login"))
+  private def isRedirectToLogin(resp: Response): Boolean = {
+    resp.status.code == Status.Found.code &&
+      resp.headers.get(Location).exists(t => t.value.contains("/cas/login") || t.value.contains("/cas-oppija/login"))
+  }
 
   private def sessionExpired(resp: Response): Boolean = {
     isRedirectToLogin(resp) || resp.status.code == Status.Unauthorized.code

--- a/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -25,13 +25,13 @@ object CasClient {
 /**
  *  Facade for establishing sessions with services protected by CAS, and also validating CAS service tickets.
  */
-class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String) extends Logging {
+class CasClient(casBaseUrl: Uri, client: Client, callerId: String) extends Logging {
   import CasClient._
 
   def this(casServer: String, client: Client, callerId: String) = this(Uri.fromString(casServer).toOption.get, client, callerId)
 
   def validateServiceTicket(service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    ServiceTicketValidator.validateServiceTicket(virkailijaLoadBalancerUrl, client, callerId, service)(serviceTicket)
+    ServiceTicketValidator.validateServiceTicket(casBaseUrl, client, callerId, service)(serviceTicket)
   }
 
   /**
@@ -44,7 +44,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
    *  Returns the session that can be used for communications later.
    */
   def fetchCasSession(params: CasParams, sessionCookieName: String = "JSESSIONID"): Task[SessionCookie] = {
-    val serviceUri = resolve(virkailijaLoadBalancerUrl, params.service.securityUri)
+    val serviceUri = resolve(casBaseUrl, params.service.securityUri)
 
     for (
       st <- getServiceTicketWithRetryOnce(params, serviceUri);
@@ -77,7 +77,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
 
   private def getServiceTicket(params: CasParams, serviceUri: TGTUrl): Task[ServiceTicket] = {
     for (
-      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(virkailijaLoadBalancerUrl, client, params, callerId);
+      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(casBaseUrl, client, params, callerId);
       st <- ServiceTicketClient.getServiceTicketFromTgt(client, serviceUri, callerId)(tgt)
     ) yield {
       st
@@ -86,8 +86,8 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
 }
 
 private[cas] object ServiceTicketValidator {
-  def validateServiceTicket(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    val pUri: Uri = virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/serviceValidate")
+  def validateServiceTicket(casBaseUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
+    val pUri: Uri = casBaseUrl.withPath(casBaseUrl.path + "/serviceValidate")
       .withQueryParam("ticket", serviceTicket)
       .withQueryParam("service",service)
 
@@ -133,8 +133,8 @@ private[cas] object ServiceTicketClient {
 private[cas] object TicketGrantingTicketClient extends Logging {
   import CasClient.TGTUrl
 
-  def getTicketGrantingTicket(virkailijaLoadBalancerUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
-    val task = POST(virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/v1/tickets"), params.user)(casUserEncoder)
+  def getTicketGrantingTicket(casBaseUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
+    val task = POST(casBaseUrl.withPath(casBaseUrl.path + "/v1/tickets"), params.user)(casUserEncoder)
     FetchHelper.fetch(client, callerId, task, decodeTgt)
   }
 

--- a/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.11/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -87,7 +87,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
 
 private[cas] object ServiceTicketValidator {
   def validateServiceTicket(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    val pUri: Uri = resolve(virkailijaLoadBalancerUrl, uri("/cas/serviceValidate"))
+    val pUri: Uri = virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/serviceValidate")
       .withQueryParam("ticket", serviceTicket)
       .withQueryParam("service",service)
 
@@ -134,7 +134,7 @@ private[cas] object TicketGrantingTicketClient extends Logging {
   import CasClient.TGTUrl
 
   def getTicketGrantingTicket(virkailijaLoadBalancerUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
-    val task = POST(resolve(virkailijaLoadBalancerUrl, uri("/cas/v1/tickets")), params.user)(casUserEncoder)
+    val task = POST(virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/v1/tickets"), params.user)(casUserEncoder)
     FetchHelper.fetch(client, callerId, task, decodeTgt)
   }
 

--- a/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.11/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -4,6 +4,7 @@ import java.net.ConnectException
 
 import fi.vm.sade.utils.cas.CasClient.SessionCookie
 import fi.vm.sade.tcp.PortChecker
+import org.http4s.Uri
 import org.http4s.client.blaze
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -25,5 +26,16 @@ class CasClientSmokeTest extends FreeSpec with Matchers {
       case _ =>
         false
     }) shouldBe true
+  }
+
+  "Http4s Uri resolve function is broken and cannot be used until upgrade" in {
+    // http4s version used by this lib doesn't support appending segments to path which is why this test is added here
+    // to remind the fortunate upgrader that if you do update the http4s, please check all uses of `resolve` function
+    // and also calls to `withPath` to ensure correct functionality across the entire CAS client library
+    //
+    // Also note that this behavior, while compatible with RFC, does not match what eg. `java.net.URI#resolve` or
+    // `java.nio.Path#resolve` does
+    (Uri.uri("http://localhost/foo").resolve(Uri.uri("/bar"))) shouldBe Uri.uri("http://localhost/bar")  // this is broken
+    (Uri.uri("http://localhost/foo").withPath("/bar")) shouldBe Uri.uri("http://localhost/bar")  // this is fine
   }
 }

--- a/scala-cas_2.12/pom.xml
+++ b/scala-cas_2.12/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.12</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.12</name>
     <properties>

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
@@ -61,7 +61,7 @@ class CasAuthenticatingClient(casClient: CasClient,
   }
 
   private def isRedirectToLogin(resp: Response): Boolean =
-    resp.status.code == Status.Found.code && resp.headers.get(Location).exists(_.value.contains("/cas/login"))
+    resp.headers.get(Location).exists(t => t.value.contains("/cas/login") || t.value.contains("/cas-oppija/login"))
 
   private def sessionExpired(resp: Response): Boolean = {
     isRedirectToLogin(resp) || resp.status.code == Status.Unauthorized.code

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -83,7 +83,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
 
 private[cas] object ServiceTicketValidator {
   def validateServiceTicket(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    val pUri: Uri = resolve(virkailijaLoadBalancerUrl, uri("/cas/serviceValidate"))
+    val pUri: Uri = virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/serviceValidate")
       .withQueryParam("ticket", serviceTicket)
       .withQueryParam("service",service)
 
@@ -136,7 +136,7 @@ private[cas] object TicketGrantingTicketClient extends Logging {
   val tgtPattern = "(.*TGT-.*)".r
 
   def getTicketGrantingTicket(virkailijaLoadBalancerUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
-    val tgtUri: TGTUrl = resolve(virkailijaLoadBalancerUrl, uri("/cas/v1/tickets"))
+    val tgtUri: TGTUrl = virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/v1/tickets")
     val task = POST(tgtUri, UrlForm("username" -> params.user.username, "password" -> params.user.password))
 
     def handler(response: Response): Task[TGTUrl] = {

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -21,13 +21,13 @@ object CasClient {
 /**
  *  Facade for establishing sessions with services protected by CAS, and also validating CAS service tickets.
  */
-class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String) extends Logging {
+class CasClient(casBaseUrl: Uri, client: Client, callerId: String) extends Logging {
   import CasClient._
 
   def this(casServer: String, client: Client, callerId: String) = this(Uri.fromString(casServer).toOption.get, client, callerId)
 
   def validateServiceTicket(service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    ServiceTicketValidator.validateServiceTicket(virkailijaLoadBalancerUrl, client, callerId, service)(serviceTicket)
+    ServiceTicketValidator.validateServiceTicket(casBaseUrl, client, callerId, service)(serviceTicket)
   }
 
   /**
@@ -40,7 +40,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
    *  Returns the session that can be used for communications later.
    */
   def fetchCasSession(params: CasParams, sessionCookieName: String = "JSESSIONID"): Task[SessionCookie] = {
-    val serviceUri = resolve(virkailijaLoadBalancerUrl, params.service.securityUri)
+    val serviceUri = resolve(casBaseUrl, params.service.securityUri)
 
     for (
       st <- getServiceTicketWithRetryOnce(params, serviceUri);
@@ -73,7 +73,7 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
 
   private def getServiceTicket(params: CasParams, serviceUri: TGTUrl): Task[ServiceTicket] = {
     for (
-      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(virkailijaLoadBalancerUrl, client, params, callerId);
+      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(casBaseUrl, client, params, callerId);
       st <- ServiceTicketClient.getServiceTicketFromTgt(client, serviceUri, callerId)(tgt)
     ) yield {
       st
@@ -82,8 +82,8 @@ class CasClient(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String
 }
 
 private[cas] object ServiceTicketValidator {
-  def validateServiceTicket(virkailijaLoadBalancerUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    val pUri: Uri = virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/serviceValidate")
+  def validateServiceTicket(casBaseUrl: Uri, client: Client, callerId: String, service: String)(serviceTicket: ServiceTicket): Task[Username] = {
+    val pUri: Uri = casBaseUrl.withPath(casBaseUrl.path + "/serviceValidate")
       .withQueryParam("ticket", serviceTicket)
       .withQueryParam("service",service)
 
@@ -135,8 +135,8 @@ private[cas] object TicketGrantingTicketClient extends Logging {
   import CasClient.TGTUrl
   val tgtPattern = "(.*TGT-.*)".r
 
-  def getTicketGrantingTicket(virkailijaLoadBalancerUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
-    val tgtUri: TGTUrl = virkailijaLoadBalancerUrl.withPath(virkailijaLoadBalancerUrl.path + "/v1/tickets")
+  def getTicketGrantingTicket(casBaseUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
+    val tgtUri: TGTUrl = casBaseUrl.withPath(casBaseUrl.path + "/v1/tickets")
     val task = POST(tgtUri, UrlForm("username" -> params.user.username, "password" -> params.user.password))
 
     def handler(response: Response): Task[TGTUrl] = {

--- a/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -4,6 +4,7 @@ import java.net.ConnectException
 
 import fi.vm.sade.utils.cas.CasClient.SessionCookie
 import fi.vm.sade.tcp.PortChecker
+import org.http4s.Uri
 import org.http4s.client.blaze
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -25,5 +26,16 @@ class CasClientSmokeTest extends FreeSpec with Matchers {
       case _ =>
         false
     }) shouldBe true
+  }
+
+  "Http4s Uri resolve function is broken and cannot be used until upgrade" in {
+    // http4s version used by this lib doesn't support appending segments to path which is why this test is added here
+    // to remind the fortunate upgrader that if you do update the http4s, please check all uses of `resolve` function
+    // and also calls to `withPath` to ensure correct functionality across the entire CAS client library
+    //
+    // Also note that this behavior, while compatible with RFC, does not match what eg. `java.net.URI#resolve` or
+    // `java.nio.Path#resolve` does
+    (Uri.uri("http://localhost/foo").resolve(Uri.uri("/bar"))) shouldBe Uri.uri("http://localhost/bar")  // this is broken
+    (Uri.uri("http://localhost/foo").withPath("/bar")) shouldBe Uri.uri("http://localhost/bar")  // this is fine
   }
 }


### PR DESCRIPTION
Some hardcoded paths within the client aren't nice, replaced those with relative path resolving. Also turns out http4s is so old that it doesn't support path segment appending and its resolve is slightly broken, which is why the lithmus smoke test was added in case someone updates the http4s library in the future.