### PR TITLE
Päivitä scala-cas_2.12 http4s versioon 0.23

### DIFF
--- a/scala-cas_2.12/pom.xml
+++ b/scala-cas_2.12/pom.xml
@@ -8,12 +8,13 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>scala-cas_2.12</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-cas_2.12</name>
     <properties>
         <scala.compat.version>2.12</scala.compat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <http4s.version>0.23.4</http4s.version>
     </properties>
     <dependencies>
         <dependency>
@@ -39,17 +40,17 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-            <version>0.16.6a</version>
+            <version>${http4s.version}</version>
         </dependency>
         <dependency>
             <groupId>org.http4s</groupId>
             <artifactId>http4s-dsl_${scala.compat.version}</artifactId>
-            <version>0.16.6a</version>
+            <version>${http4s.version}</version>
         </dependency>
         <dependency>
             <groupId>org.http4s</groupId>
             <artifactId>http4s-blaze-client_${scala.compat.version}</artifactId>
-            <version>0.16.6a</version>
+            <version>${http4s.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasAuthenticatingClient.scala
@@ -1,86 +1,82 @@
 package fi.vm.sade.utils.cas
 
-import fi.vm.sade.utils.cas.CasClient._
-import scala.collection.mutable.ListBuffer
-
-import org.http4s.{headers, _}
-import org.http4s.client.{Client, DisposableResponse}
-import org.http4s.headers.Location
-
-import scalaz.concurrent.Task
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.effect.std.Hotswap
+import fi.vm.sade.utils.cas.CasClient.SessionCookie
+import org.http4s.client.Client
+import org.http4s.{Request, Response, Status}
+import org.typelevel.ci.CIString
 
 
 /**
- *  HTTP client implementation that handles CAS authentication automatically. Sessions are maintained by keeping
+ *  Middleware that handles CAS authentication automatically. Sessions are maintained by keeping
  *  a central cache of session cookies per service url. If a session cookie is not found for requested service, it is obtained using
  *  CasClient. Stale sessions are detected and refreshed automatically.
  */
 object CasAuthenticatingClient extends Logging {
-  def apply(casClient: CasClient,
-            casParams: CasParams,
-            serviceClient: Client,
-            clientCallerId: String,
-            sessionCookieName: String): Client = {
-    new CasAuthenticatingClient(casClient, casParams, serviceClient, clientCallerId, sessionCookieName).httpClient
-  }
-}
-
-class CasAuthenticatingClient(casClient: CasClient,
-                              casParams: CasParams,
-                              serviceClient: Client,
-                              clientCallerId: String,
-                              sessionCookieName: String) extends Logging {
-  lazy val httpClient = Client(
-    open = Service.lift(open),
-    shutdown = serviceClient.shutdown
-  )
+  val DefaultSessionCookieName = "JSESSIONID"
 
   private val sessions: collection.mutable.Map[CasParams, SessionCookie] = collection.mutable.Map.empty
 
-  private def open(req: Request): Task[DisposableResponse] = {
-    openWithCasSession(getCasSession(casParams), req).flatMap {
-      case resp if sessionExpired(resp.response) =>
-        logger.debug("Session for " + casParams + " expired")
-        resp.dispose.flatMap(_ => openWithCasSession(refreshSession(casParams), req))
-      case resp =>
-        Task.now(resp)
+  def apply(
+    casClient: CasClient,
+    casParams: CasParams,
+    serviceClient: Client[IO],
+    clientCallerId: String,
+    sessionCookieName: String = DefaultSessionCookieName
+  ): Client[IO] = {
+    def openWithCasSession(request: Request[IO], hotswap: Hotswap[IO, Response[IO]]): IO[Response[IO]] = {
+      getCasSession(casParams).flatMap(requestWithCasSession(request, hotswap, retry = true))
     }
-  }
 
-  private def addHeaders(req: Request, session: SessionCookie): Request = {
-    val list: List[Header] = List(headers.Cookie(Cookie(sessionCookieName, session), Cookie("CSRF", clientCallerId)), Header("CSRF", clientCallerId), Header("Caller-Id", clientCallerId))
-    req.putHeaders(list: _*)
-  }
-
-  private def openWithCasSession(sessionIdTask: Task[SessionCookie], request: Request): Task[DisposableResponse] = {
-    sessionIdTask.flatMap { jsessionid =>
-      val requestWithHeaders = addHeaders(request, jsessionid)
-      serviceClient.open(requestWithHeaders)
+    def requestWithCasSession
+      (request: Request[IO], hotswap: Hotswap[IO, Response[IO]], retry: Boolean)
+      (sessionCookie: SessionCookie)
+    : IO[Response[IO]] = {
+      val fullRequest = FetchHelper.addDefaultHeaders(
+        request.addCookie(sessionCookieName, sessionCookie),
+        clientCallerId
+      )
+      // Hotswap use inspired by http4s Retry middleware:
+      hotswap.swap(serviceClient.run(fullRequest)).flatMap {
+        case r: Response[IO] if sessionExpired(r) && retry =>
+          logger.info("Session for " + casParams + " expired")
+          refreshSession(casParams).flatMap(requestWithCasSession(request, hotswap, retry = false))
+        case r: Response[IO] => IO.pure(r)
+      }
     }
-  }
 
-  private def isRedirectToLogin(resp: Response): Boolean =
-    resp.headers.get(Location).exists(t => t.value.contains("/cas/login") || t.value.contains("/cas-oppija/login"))
+    def isRedirectToLogin(resp: Response[IO]): Boolean =
+      resp.headers.get(CIString("Location")).exists(_.exists(header =>
+        header.value.contains("/cas/login") || header.value.contains("/cas-oppija/login")
+      ))
 
-  private def sessionExpired(resp: Response): Boolean = {
-    isRedirectToLogin(resp) || resp.status.code == Status.Unauthorized.code
-}
+    def sessionExpired(resp: Response[IO]): Boolean =
+      isRedirectToLogin(resp) || resp.status == Status.Unauthorized
 
-  private def getCasSession(params: CasParams): Task[SessionCookie] = {
-    synchronized(sessions.get(params)) match {
-      case None =>
-        logger.debug(s"No existing $sessionCookieName found for " + params + ", creating new")
-        refreshSession(params)
-      case Some(session) =>
-        Task.now(session)
+    def getCasSession(params: CasParams): IO[SessionCookie] = {
+      synchronized(sessions.get(params)) match {
+        case None =>
+          logger.debug(s"No existing $sessionCookieName found for " + params + ", creating new")
+          refreshSession(params)
+        case Some(session) =>
+          IO.pure(session)
+      }
     }
-  }
 
-  private def refreshSession(params: CasParams): Task[SessionCookie] = {
-    casClient.fetchCasSession(params, sessionCookieName).map { session =>
-      logger.debug("Storing new jsessionid for " + params)
-      synchronized(sessions.put(params, session))
-      session
+    def refreshSession(params: CasParams): IO[SessionCookie] = {
+      casClient.fetchCasSession(params, sessionCookieName).map { session =>
+        logger.debug("Storing new session for " + params)
+        synchronized(sessions.put(params, session))
+        session
+      }
+    }
+
+    Client { req =>
+      Hotswap.create[IO, Response[IO]].flatMap { hotswap =>
+        Resource.eval(openWithCasSession(req, hotswap))
+      }
     }
   }
 }

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasClient.scala
@@ -1,17 +1,16 @@
 package fi.vm.sade.utils.cas
 
+import cats.data.EitherT
+import cats.effect.IO
 import org.http4s.EntityDecoder.collectBinary
-import org.http4s.Status.Created
-import org.http4s.{Header, Response, _}
+import org.http4s.Status.{Created, Locked}
 import org.http4s.client._
-import org.http4s.dsl._
-import org.http4s.headers.{Location, `Set-Cookie`}
-
-import scala.xml._
-import scalaz.concurrent.Task
-import scalaz.{-\/, \/-}
+import org.http4s._
+import org.typelevel.ci.CIString
 
 import scala.util.{Failure, Success, Try}
+import scala.xml._
+
 
 object CasClient {
   type SessionCookie = String
@@ -19,38 +18,48 @@ object CasClient {
   type OppijaAttributes = Map[String, String]
   type TGTUrl = Uri
   type ServiceTicket = String
-  val textOrXmlDecoder = EntityDecoder.decodeBy(MediaRange.`text/*`, MediaType.`application/xml`)(msg =>
-    collectBinary(msg).map(bs => new String(bs.toArray, msg.charset.getOrElse(DefaultCharset).nioCharset))
-  )
+
+  val textOrXmlDecoder: EntityDecoder[IO, String] =
+    EntityDecoder.decodeBy(MediaRange.`text/*`, MediaType.application.xml)(msg =>
+      collectBinary(msg).map(bs => new String(
+        bs.toArray,
+        msg.charset.getOrElse(DefaultCharset).nioCharset
+      ))
+    )
 }
 
 /**
  *  Facade for establishing sessions with services protected by CAS, and also validating CAS service tickets.
  */
-class CasClient(casBaseUrl: Uri, client: Client, callerId: String) extends Logging {
+class CasClient(casBaseUrl: Uri, client: Client[IO], callerId: String) extends Logging {
   import CasClient._
 
-  def this(casServer: String, client: Client, callerId: String) = this(Uri.fromString(casServer).toOption.get, client, callerId)
+  def this(casServer: String, client: Client[IO], callerId: String) = this(Uri.fromString(casServer).right.get, client, callerId)
 
-  def validateServiceTicketWithOppijaAttributes(service: String)(serviceTicket: ServiceTicket): Task[OppijaAttributes] = {
-    validateServiceTicket[OppijaAttributes](casBaseUrl, client, callerId, service, decodeOppijaAttributes)(serviceTicket)
+  def validateServiceTicketWithOppijaAttributes(service: String)(serviceTicket: ServiceTicket): IO[OppijaAttributes] = {
+    validateServiceTicket[OppijaAttributes](casBaseUrl, client, service, decodeOppijaAttributes)(serviceTicket)
   }
 
-  def validateServiceTicketWithVirkailijaUsername(service: String)(serviceTicket: ServiceTicket): Task[Username] = {
-    validateServiceTicket[Username](casBaseUrl, client, callerId, service, decodeVirkailijaUsername)(serviceTicket)
+  def validateServiceTicketWithVirkailijaUsername(service: String)(serviceTicket: ServiceTicket): IO[Username] = {
+    validateServiceTicket[Username](casBaseUrl, client, service, decodeVirkailijaUsername)(serviceTicket)
   }
 
-  def validateServiceTicket[R](service: String)(serviceTicket: ServiceTicket, responseHandler: Response => Task[R]): Task[R] = {
-    validateServiceTicket[R](casBaseUrl, client, callerId, service, responseHandler)(serviceTicket)
+  def validateServiceTicket[R](service: String)(serviceTicket: ServiceTicket, responseHandler: Response[IO] => IO[R]): IO[R] = {
+    validateServiceTicket[R](casBaseUrl, client, service, responseHandler)(serviceTicket)
   }
 
-  private def validateServiceTicket[R](casBaseUrl: Uri, client: Client, callerId: String, service: String, responseHandler: Response => Task[R])(serviceTicket: ServiceTicket): Task[R] = {
-    val pUri: Uri = casBaseUrl.withPath(casBaseUrl.path + "/serviceValidate")
+  private def validateServiceTicket[R](casBaseUrl: Uri, client: Client[IO], service: String, responseHandler: Response[IO] => IO[R])(serviceTicket: ServiceTicket): IO[R] = {
+    val pUri: Uri = casBaseUrl.addPath("serviceValidate")
       .withQueryParam("ticket", serviceTicket)
-      .withQueryParam("service",service)
+      .withQueryParam("service", service)
 
-    val task = GET(pUri)
-    FetchHelper.fetch[R](client, callerId: String, task, responseHandler)
+    val request = Request[IO](Method.GET, pUri)
+    FetchHelper.fetch[R](client, callerId, request, responseHandler)
+  }
+
+  def authenticateVirkailija(user: CasUser): IO[Boolean] = {
+    TicketGrantingTicketClient.getTicketGrantingTicket(casBaseUrl, client, user, callerId)
+      .map(_tgtUrl => true) // Authentication succeeded if we received a tgtUrl
   }
 
   /**
@@ -62,8 +71,8 @@ class CasClient(casBaseUrl: Uri, client: Client, callerId: String) extends Loggi
    *
    *  Returns the session that can be used for communications later.
    */
-  def fetchCasSession(params: CasParams, sessionCookieName: String = "JSESSIONID"): Task[SessionCookie] = {
-    val serviceUri = resolve(casBaseUrl, params.service.securityUri)
+  def fetchCasSession(params: CasParams, sessionCookieName: String): IO[SessionCookie] = {
+    val serviceUri = Uri.resolve(casBaseUrl, params.service.securityUri)
 
     for (
       st <- getServiceTicketWithRetryOnce(params, serviceUri);
@@ -73,181 +82,210 @@ class CasClient(casBaseUrl: Uri, client: Client, callerId: String) extends Loggi
     }
   }
 
-  private def getServiceTicketWithRetryOnce(params: CasParams, serviceUri: TGTUrl): Task[ServiceTicket] = {
+  private def getServiceTicketWithRetryOnce(params: CasParams, serviceUri: TGTUrl): IO[ServiceTicket] = {
     getServiceTicket(params, serviceUri).attempt.flatMap {
-      case \/-(success) =>
-        Task(success)
-      case -\/(throwable) =>
+      case Right(success) =>
+        IO(success)
+      case Left(throwable) =>
         logger.warn("Fetching TGT or ST failed. Retrying once (and only once) in case the error was ephemeral.", throwable)
-        retryServiceTicket(params, serviceUri, callerId)
+        retryServiceTicket(params, serviceUri)
     }
   }
 
-  private def retryServiceTicket(params: CasParams, serviceUri: TGTUrl, callerId: String): Task[ServiceTicket] = {
+  private def retryServiceTicket(params: CasParams, serviceUri: TGTUrl): IO[ServiceTicket] = {
     getServiceTicket(params, serviceUri).attempt.map {
-      case \/-(retrySuccess) =>
+      case Right(retrySuccess) =>
         logger.info("Fetching TGT and ST was successful after one retry.")
         retrySuccess
-      case -\/(retryThrowable) =>
+      case Left(retryThrowable) =>
         logger.error("Fetching TGT or ST failed also after one retry.", retryThrowable)
         throw retryThrowable
     }
   }
 
-  private def getServiceTicket(params: CasParams, serviceUri: TGTUrl): Task[ServiceTicket] = {
-    for (
-      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(casBaseUrl, client, params, callerId);
+  private def getServiceTicket(params: CasParams, serviceUri: TGTUrl): IO[ServiceTicket] = {
+    for {
+      tgt <- TicketGrantingTicketClient.getTicketGrantingTicket(casBaseUrl, client, params.user, callerId)
       st <- ServiceTicketClient.getServiceTicketFromTgt(client, serviceUri, callerId)(tgt)
-    ) yield {
+    } yield {
       st
     }
   }
 
-  private val oppijaServiceTicketDecoder: EntityDecoder[OppijaAttributes] = textOrXmlDecoder
-    .map(s => Utility.trim(scala.xml.XML.loadString(s)))
-    .flatMapR[OppijaAttributes] { serviceResponse =>
-      Try {
-        val attributes: NodeSeq = (serviceResponse \ "authenticationSuccess" \ "attributes")
-
-        List("mail", "clientName", "displayName", "givenName", "personOid", "personName", "firstName", "nationalIdentificationNumber",
-          "impersonatorNationalIdentificationNumber", "impersonatorDisplayName")
-          .map(key => (key, (attributes \ key).text))
-          .toMap
-      } match {
-        case Success(decoded) => DecodeResult.success(decoded)
-        case Failure(ex) => DecodeResult.failure(InvalidMessageBodyFailure("Oppija Service Ticket validation response decoding failed: Failed to parse required values from response body", Some(ex)))
-      }
-    }
-
-  private val virkailijaServiceTicketDecoder: EntityDecoder[Username] = textOrXmlDecoder
-    .map(s => Utility.trim(scala.xml.XML.loadString(s)))
-    .flatMapR[Username] {
-      case <cas:serviceResponse><cas:authenticationSuccess><cas:user>{user}</cas:user></cas:authenticationSuccess></cas:serviceResponse> => DecodeResult.success(user.text)
-      case authenticationFailure => DecodeResult.failure(InvalidMessageBodyFailure(s"Virkailija Service Ticket validation response decoding failed: response body is of wrong form ($authenticationFailure)"))
-    }
-
-  private val casFailure = (debugLabel: String, resp: Response) => {
+  private val oppijaServiceTicketDecoder: EntityDecoder[IO, OppijaAttributes] =
     textOrXmlDecoder
-      .decode(resp, true)
-      .fold(
-        (_) => InvalidMessageBodyFailure(s"Decoding $debugLabel failed: CAS returned non-ok status code ${resp.status.code}"),
-        (body) => InvalidMessageBodyFailure(s"Decoding $debugLabel failed: CAS returned non-ok status code ${resp.status.code}: $body"))
+      .map(s => Utility.trim(scala.xml.XML.loadString(s)))
+      .flatMapR[OppijaAttributes] { serviceResponse =>
+        Try {
+          val attributes: NodeSeq = (serviceResponse \ "authenticationSuccess" \ "attributes")
+
+          List("mail", "clientName", "displayName", "givenName", "personOid", "personName", "firstName", "nationalIdentificationNumber",
+            "impersonatorNationalIdentificationNumber", "impersonatorDisplayName")
+            .map(key => (key, (attributes \ key).text))
+            .toMap
+        } match {
+          case Success(decoded) => DecodeResult.successT(decoded)
+          case Failure(ex) =>
+            DecodeResult.failureT(InvalidMessageBodyFailure(
+              "Oppija Service Ticket validation response decoding failed: Failed to parse required values from response body",
+              Some(ex))
+            )
+        }
+      }
+
+  private val virkailijaServiceTicketDecoder: EntityDecoder[IO, Username] =
+    textOrXmlDecoder
+      .map(s => Utility.trim(scala.xml.XML.loadString(s)))
+      .flatMapR[Username] {
+        case <cas:serviceResponse><cas:authenticationSuccess><cas:user>{user}</cas:user></cas:authenticationSuccess></cas:serviceResponse> =>
+          DecodeResult.successT(user.text)
+        case authenticationFailure: Node =>
+          DecodeResult.failureT(InvalidMessageBodyFailure(
+            s"Virkailija Service Ticket validation response decoding failed: response body is of wrong form ($authenticationFailure)"
+          ))
+      }
+
+  private def casFailure[R](debugLabel: String, resp: Response[IO]): EitherT[IO, DecodeFailure, R] = {
+    textOrXmlDecoder
+      .decode(resp, strict = false)
+      .flatMap(body => DecodeResult.failureT[IO, R](InvalidMessageBodyFailure(
+        s"Decoding $debugLabel failed: CAS returned non-ok status code ${resp.status.code}: $body"
+      )))
+      .leftFlatMap(failure => DecodeResult.failureT[IO, R](InvalidMessageBodyFailure(
+        s"Decoding $debugLabel failed: CAS returned non-ok status code ${resp.status.code}: ${failure.message}"
+      )))
   }
 
   /**
    * Decode CAS Oppija's service ticket validation response to various oppija attributes.
    */
-  def decodeOppijaAttributes: (Response) => Task[OppijaAttributes] = { response =>
+  def decodeOppijaAttributes: Response[IO] => IO[OppijaAttributes] = { response =>
     decodeCASResponse[OppijaAttributes](response, "oppija attributes", oppijaServiceTicketDecoder)
   }
 
   /**
    * Decode CAS Virkailija's service ticket validation response to username.
    */
-  def decodeVirkailijaUsername: (Response) => Task[Username] = { response =>
+  def decodeVirkailijaUsername: Response[IO] => IO[Username] = { response =>
     decodeCASResponse[Username](response, "username", virkailijaServiceTicketDecoder)
   }
 
-  private def decodeCASResponse[R](response: Response, debugLabel: String, decoder: EntityDecoder[R]): Task[R] = {
-    DecodeResult.success(response)
-      .flatMap[R] {
-        case resp if resp.status.isSuccess => decoder.decode(resp, true)
-        case resp                          => DecodeResult.failure(casFailure.apply(debugLabel, resp))
-      }.fold(e => throw new CasClientException(e.message), identity)
+  private def decodeCASResponse[R](response: Response[IO], debugLabel: String, decoder: EntityDecoder[IO, R]): IO[R] = {
+    val decodeResult = if (response.status.isSuccess) {
+      decoder
+        .decode(response, strict = false)
+        .leftMap(decodeFailure => new CasClientException(s"Decoding $debugLabel failed: " + decodeFailure.message))
+    } else {
+      casFailure(debugLabel, response)
+    }
+    decodeResult.rethrowT
   }
 }
 
 private[cas] object ServiceTicketClient {
   import CasClient._
 
-  def getServiceTicketFromTgt(client: Client, service: Uri, callerId: String)(tgtUrl: TGTUrl): Task[ServiceTicket] = {
-    val task = POST(tgtUrl, UrlForm("service" -> service.toString()))
+  private val stPattern = "(ST-.*)".r
 
-    def handler(response: Response): Task[ServiceTicket] = {
+  def getServiceTicketFromTgt(client: Client[IO], service: Uri, callerId: String)(tgtUrl: TGTUrl): IO[ServiceTicket] = {
+    val urlForm = UrlForm("service" -> service.toString())
+    val request = Request[IO](Method.POST, tgtUrl).withEntity(urlForm)
+
+    def handler(response: Response[IO]): IO[ServiceTicket] = {
       response match {
-        case r if r.status.isSuccess => r.as[String].map {
+        case r: Response[IO] if r.status.isSuccess => r.as[String].map {
           case stPattern(st) => st
-          case nonSt => throw new CasClientException(s"Service Ticket decoding failed at ${tgtUrl}: response body is of wrong form ($nonSt)")
+          case nonSt: Any => throw new CasClientException(s"Service Ticket decoding failed at ${tgtUrl}: response body is of wrong form ($nonSt)")
         }
-        case r => r.as[String].map {
-          case body => throw new CasClientException(s"Service Ticket decoding failed at ${tgtUrl}: unexpected status ${r.status.code}: $body")
-        }
+        case r: Response[IO] => r.as[String].map(body =>
+          throw new CasClientException(s"Service Ticket decoding failed at ${tgtUrl}: unexpected status ${r.status.code}: $body")
+        )
       }
     }
-    FetchHelper.fetch(client, callerId, task, handler)
+    FetchHelper.fetch(client, callerId, request, handler)
   }
-
-  val stPattern = "(ST-.*)".r
 }
 
 private[cas] object TicketGrantingTicketClient extends Logging {
   import CasClient.TGTUrl
-  val tgtPattern = "(.*TGT-.*)".r
 
-  def getTicketGrantingTicket(casBaseUrl: Uri, client: Client, params: CasParams, callerId: String): Task[TGTUrl] = {
-    val tgtUri: TGTUrl = casBaseUrl.withPath(casBaseUrl.path + "/v1/tickets")
-    val task = POST(tgtUri, UrlForm("username" -> params.user.username, "password" -> params.user.password))
+  private val tgtPattern = "(.*TGT-.*)".r
 
-    def handler(response: Response): Task[TGTUrl] = {
+  def getTicketGrantingTicket(casBaseUrl: Uri, client: Client[IO], user: CasUser, callerId: String): IO[TGTUrl] = {
+    val tgtUri: TGTUrl = casBaseUrl.addPath("v1/tickets")
+    val urlForm = UrlForm("username" -> user.username, "password" -> user.password)
+    val request = Request[IO](Method.POST, tgtUri).withEntity(urlForm)
+
+    def handler(response: Response[IO]): IO[TGTUrl] = {
       response match {
         case Created(resp) =>
-          val found: TGTUrl = resp.headers.get(Location).map(_.value) match {
+          val found: TGTUrl = resp.headers.get(CIString("Location")).map(_.head.value) match {
             case Some(tgtPattern(tgtUrl)) =>
               Uri.fromString(tgtUrl).fold(
                 (pf: ParseFailure) => throw new CasClientException(pf.message),
                 (tgt) => tgt
               )
-            case Some(nontgturl) =>
-              throw new CasClientException(s"TGT decoding failed at ${tgtUri}: location header has wrong format $nontgturl")
+            case Some(nonTgtUrl) =>
+              throw new CasClientException(s"TGT decoding failed at ${tgtUri}: location header has wrong format $nonTgtUrl")
             case None =>
-              throw new CasClientException("TGT decoding failed at ${tgtUri}: No location header at")
+              throw new CasClientException(s"TGT decoding failed at ${tgtUri}: no location header")
           }
-          Task.now(found)
-        case r => r.as[String].map { body =>
-          throw new CasClientException(s"TGT decoding failed at ${tgtUri}: invalid TGT creation status: ${r.status.code}: $body")
-        }
+          IO.pure(found)
+        case Locked(_) =>
+          throw new CasAuthenticationException(s"Access denied: username ${user.username} is locked")
+        case resp: Response[IO] => resp.as[String].map(body =>
+          if (body.contains("authentication_exceptions") || body.contains("error.authentication.credentials.bad")) {
+            throw new CasAuthenticationException(s"Access denied: bad credentials")
+          } else {
+            throw new CasClientException(s"TGT decoding failed at ${tgtUri}: invalid TGT creation status: ${resp.status.code}: $body")
+          }
+        )
       }
     }
-    FetchHelper.fetch(client, callerId, task, handler)
+    FetchHelper.fetch(client, callerId, request, handler)
   }
 }
 
 private[cas] object SessionCookieClient {
   import CasClient._
 
-  def getSessionCookieValue(client: Client, service: Uri, sessionCookieName: String, callerId: String)(serviceTicket: ServiceTicket): Task[SessionCookie] = {
-    val sessionIdUri: Uri = service.withQueryParam("ticket", List(serviceTicket)).asInstanceOf[Uri]
-    val task = GET(sessionIdUri)
+  def getSessionCookieValue
+    (client: Client[IO], service: Uri, sessionCookieName: String, callerId: String)
+    (serviceTicket: ServiceTicket)
+  : IO[SessionCookie] = {
+    val sessionIdUri: Uri = service.withQueryParam("ticket", serviceTicket)
+    val request = Request[IO](Method.GET, sessionIdUri)
 
-    def handler(response: Response): Task[SessionCookie] = {
+    def handler(response: Response[IO]): IO[SessionCookie] = {
       response match {
-        case resp if resp.status.isSuccess =>
-          Task.now(resp.headers.collectFirst {
-            case `Set-Cookie`(`Set-Cookie`(cookie)) if cookie.name == sessionCookieName => cookie.content
-          }.getOrElse(throw new CasClientException(s"Decoding $sessionCookieName failed at ${sessionIdUri}: no cookie found for JSESSIONID")))
-
-        case r => r.as[String].map { body =>
-          throw new CasClientException(s"Decoding $sessionCookieName failed at ${sessionIdUri}: service returned non-ok status code ${r.status.code}: $body")
-        }
+        case resp: Response[IO] if resp.status.isSuccess =>
+          IO.pure(
+            resp.cookies.find(_.name == sessionCookieName).map(_.content)
+              .getOrElse(throw new CasClientException(s"Decoding $sessionCookieName failed at ${sessionIdUri}: no cookie found"))
+          )
+        case resp: Response[IO] =>
+          resp.as[String].map(body =>
+            throw new CasClientException(s"Decoding $sessionCookieName failed at ${sessionIdUri}: service returned non-ok status code ${resp.status.code}: $body")
+          )
       }
     }
 
-    FetchHelper.fetch(client, callerId, task, handler)
+    FetchHelper.fetch(client, callerId, request, handler)
   }
 }
 
-private object FetchHelper {
-  private def addDefaultHeaders(task: Task[Request], callerId: String): Task[Request] = {
-    task.putHeaders(
-      Header("Caller-Id", callerId),
-      Header("CSRF", callerId)
+object FetchHelper {
+  def addDefaultHeaders(request: Request[IO], callerId: String): Request[IO] = {
+    request.putHeaders(
+      Header.Raw(CIString("Caller-Id"), callerId),
+      Header.Raw(CIString("CSRF"), callerId)
     ).addCookie("CSRF", callerId)
   }
 
-  def fetch[A](client: Client, callerId: String, task: Task[Request], handler: Response => Task[A]): Task[A] = {
-    val taskWithHeaders: Task[Request] = addDefaultHeaders(task, callerId)
-    client.fetch(taskWithHeaders)(handler)
-  }
+  def fetch[A](client: Client[IO], callerId: String, request: Request[IO], handler: Response[IO] => IO[A]): IO[A] =
+    client.run(addDefaultHeaders(request, callerId)).use(handler)
 }
 
 class CasClientException(message: String) extends RuntimeException(message)
+
+class CasAuthenticationException(message: String) extends CasClientException(message)

--- a/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasParams.scala
+++ b/scala-cas_2.12/src/main/scala/fi/vm/sade/utils/cas/CasParams.scala
@@ -1,30 +1,39 @@
 package fi.vm.sade.utils.cas
 
-import org.http4s.dsl.resolve
 import org.http4s.{ParseFailure, Uri}
+
 
 case class CasUser(username: String, password: String)
 
-case class CasService(securityUri:Uri)
+case class CasService(securityUri: Uri)
 
 case class CasParams(service: CasService, user: CasUser) {
   override def toString: String = service.securityUri.toString
 }
 
 object CasParams {
-  def apply(service: String, securityUriSuffix: String, username: String, password: String): CasParams ={
-    Uri.fromString(ensureTrailingSlash(service)).fold(
+  def apply(servicePath: String, securityUriSuffix: String, username: String, password: String): CasParams = {
+    Uri.fromString(ensureTrailingSlash(ensureLeadingSlash(servicePath))).fold(
       (e: ParseFailure) => throw new IllegalArgumentException(e),
-      (service: Uri) => CasParams(CasService(resolve(service, Uri.fromString(securityUriSuffix).getOrElse {
+      (service: Uri) => CasParams(CasService(Uri.resolve(service / "", Uri.fromString(securityUriSuffix).getOrElse {
         throw new IllegalArgumentException(s"Could not parse securityUriSuffix $securityUriSuffix")
       })), CasUser(username, password)))
   }
 
-  def apply(service: String, username: String, password: String): CasParams = apply(service = service,
-    securityUriSuffix = "j_spring_cas_security_check", username = username, password = password)
+  def apply(servicePath: String, username: String, password: String): CasParams = apply(
+    servicePath = servicePath,
+    securityUriSuffix = "j_spring_cas_security_check",
+    username = username,
+    password = password
+  )
 
-  private def ensureTrailingSlash(service:String) = service.last match {
-    case '/' => service
-    case _ => service + "/"
+  private def ensureTrailingSlash(servicePath: String): String = servicePath.last match {
+    case '/' => servicePath
+    case _ => servicePath + "/"
+  }
+
+  private def ensureLeadingSlash(servicePath: String): String = servicePath.head match {
+    case '/' => servicePath
+    case _ => "/" + servicePath
   }
 }

--- a/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasAuthenticatingClientIntegrationTest.scala
+++ b/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasAuthenticatingClientIntegrationTest.scala
@@ -20,15 +20,15 @@ class CasAuthenticatingClientIntegrationTest extends FreeSpec with Matchers {
     val virkailijaUser: String = requiredEnv("VIRKAILIJA_USER")
     val virkailijaPassword: String = requiredEnv("VIRKAILIJA_PASSWORD")
 
-    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient, "my-caller-id")
+    val casClient = new CasClient(virkailijaUrl + "/cas", blaze.defaultClient, "my-caller-id")
     val casAuthenticatingClient = CasAuthenticatingClient(
       casClient,
-      CasParams("/authentication-service", virkailijaUser, virkailijaPassword),
+      CasParams("/kayttooikeus-service", virkailijaUser, virkailijaPassword),
       blaze.defaultClient,
       "koski",
       "JSESSIONID"
     )
-    val request = Request(uri = uriFromString(virkailijaUrl + "/authentication-service/resources/omattiedot"))
+    val request = Request(uri = uriFromString(virkailijaUrl + "/kayttooikeus-service/henkilo/current/omattiedot"))
     val result = casAuthenticatingClient.fetch(request) { response =>
       response.status match {
         case Status.Ok => response.as[String]

--- a/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
+++ b/scala-cas_2.12/src/test/scala/fi/vm/sade/utils/cas/CasClientSmokeTest.scala
@@ -1,41 +1,36 @@
 package fi.vm.sade.utils.cas
 
-import java.net.ConnectException
-
-import fi.vm.sade.utils.cas.CasClient.SessionCookie
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import fi.vm.sade.tcp.PortChecker
-import org.http4s.Uri
-import org.http4s.client.blaze
-import org.scalatest.{FreeSpec, Matchers}
+import fi.vm.sade.utils.cas.CasAuthenticatingClient.DefaultSessionCookieName
+import fi.vm.sade.utils.cas.CasClient.SessionCookie
+import org.http4s.blaze.client.BlazeClientBuilder
+import org.http4s.client.ConnectionFailure
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.ExecutionContext.global
 import scala.util.{Failure, Try}
 
-class CasClientSmokeTest extends FreeSpec with Matchers {
+
+class CasClientSmokeTest extends AnyFreeSpec with Matchers {
+  implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 
   val params: CasParams = CasParams("http://service", "suffix", "u", "pw")
 
   "CasClient fetch session should fail with correct (inner) exception instead of some functional problem" in {
     val virkailijaUrl = "http://localhost:" + PortChecker.findFreeLocalPort()
-    val casClient = new CasClient(virkailijaUrl, blaze.defaultClient, "my-caller-id")
+    val blazeClient = BlazeClientBuilder[IO](global).allocated.map(_._1).unsafeRunSync()
+    val casClient = new CasClient(virkailijaUrl, blazeClient, "my-caller-id")
 
-    val result: Try[SessionCookie] = Try(casClient.fetchCasSession(params).unsafePerformSync)
+    val result: Try[SessionCookie] = Try(casClient.fetchCasSession(params, DefaultSessionCookieName).unsafeRunSync())
 
-    (result match {
-      case Failure(e) if e.isInstanceOf[ConnectException] && e.getMessage.equals("Connection refused") =>
-        true
-      case _ =>
-        false
-    }) shouldBe true
-  }
-
-  "Http4s Uri resolve function is broken and cannot be used until upgrade" in {
-    // http4s version used by this lib doesn't support appending segments to path which is why this test is added here
-    // to remind the fortunate upgrader that if you do update the http4s, please check all uses of `resolve` function
-    // and also calls to `withPath` to ensure correct functionality across the entire CAS client library
-    //
-    // Also note that this behavior, while compatible with RFC, does not match what eg. `java.net.URI#resolve` or
-    // `java.nio.Path#resolve` does
-    (Uri.uri("http://localhost/foo").resolve(Uri.uri("/bar"))) shouldBe Uri.uri("http://localhost/bar")  // this is broken
-    (Uri.uri("http://localhost/foo").withPath("/bar")) shouldBe Uri.uri("http://localhost/bar")  // this is fine
+    result match {
+      case Failure(e) =>
+        e shouldBe a[ConnectionFailure]
+        e.getMessage should startWith("Error connecting to")
+      case _ => fail("Should not succeed")
+    }
   }
 }


### PR DESCRIPTION
Päivitetään http4s uusimpaan vakaaseen versioon kosken ja oma-opintopolku-lokin kirjastopäivityksiä varten.

Bumpataan paketin versionumeroksi 3.0.0 koska tämä on erittäin rikkova muutos.